### PR TITLE
Fix spark icon

### DIFF
--- a/mappings/:spark:
+++ b/mappings/:spark:
@@ -1,1 +1,1 @@
-"Spark"
+"Spark Desktop"


### PR DESCRIPTION
Spark mail app goes by the name Spark Desktop.