### PR TITLE
Adding System Settings to gear mapping

### DIFF
--- a/mappings/:gear:
+++ b/mappings/:gear:
@@ -1,1 +1,1 @@
-"System Preferences" | "系统设置"
+"System Preferences" | "System Settings" | "系统设置"


### PR DESCRIPTION
Newer Mac versions uses System Settings instead of System Preferences, so I added it to the mapping without replacing for backwards compatibility.