### PR TITLE
Update :rider: mapping

### DIFF
--- a/mappings/:rider:
+++ b/mappings/:rider:
@@ -1,1 +1,1 @@
-"Rider"
+"Rider" | "JetBrains Rider"


### PR DESCRIPTION
Apologies—missed the "JetBrains" in the name which seems to appear specifically in Rider (at least some versions).