### PR TITLE
Add support for new teams work or school

### DIFF
--- a/mappings/:microsoft_teams:
+++ b/mappings/:microsoft_teams:
@@ -1,1 +1,1 @@
-"Microsoft Teams"
+"Microsoft Teams" | "Microsoft Teams (work or school)"


### PR DESCRIPTION
Last year, Microsoft introduced a new Teams, named _"Microsoft Teams (work or school)"_ with the same icon. This PR adds support for the **new** Teams application.