### PR TITLE
fix whatsapp on macos from mas

### DIFF
--- a/mappings/:whats_app:
+++ b/mappings/:whats_app:
@@ -1,1 +1,1 @@
-"WhatsApp"
+"WhatsApp" | "‎WhatsApp"


### PR DESCRIPTION
WhatsApp installation via MAS includes prefixed `[U+200E]` (LRM).
Note: the git diff shows that the two entries are the same, although they aren't.
<img width="1079" alt="image" src="https://github.com/kvndrsslr/sketchybar-app-font/assets/4563751/16535273-bc18-4695-a500-662cb54a55a8">
