### PR TITLE
release.yml: include lua in artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,5 @@ jobs:
               --repo="$GITHUB_REPOSITORY" \
               --clobber \
               ./dist/icon_map.sh \
-              ./dist/sketchybar-app-font.ttf
+              ./dist/sketchybar-app-font.ttf \
+              ./dist/icon_map.lua


### PR DESCRIPTION
I was originally going to update the nixpkg to build from source and grab the lua files... but pnpm support in nixpkgs looks awful to implement until another PR for making a builder for it. Just proposing including the new lua file in the artifacts upload so i can grab the built lua file from the releases. 