### PR TITLE
build json mapping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release System Version
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   build:
@@ -16,8 +16,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'pnpm'
+          node-version: "20"
+          cache: "pnpm"
       - run: pnpm i
       - run: pnpm run build
       # create a release with the tag name and the build artifacts (./dist/icon_map.sh and ./dist/sketchybar-app-font.ttf)
@@ -36,4 +36,5 @@ jobs:
               --clobber \
               ./dist/icon_map.sh \
               ./dist/sketchybar-app-font.ttf \
-              ./dist/icon_map.lua
+              ./dist/icon_map.lua \
+              ./dist/icon_map.json

--- a/build.js
+++ b/build.js
@@ -64,6 +64,15 @@ ${iconMap
   // chmod +x ./dist/icon_map.sh
   fs.chmodSync("./dist/icon_map.sh", 0o755);
 
+  const iconMapJson = JSON.stringify(iconMap.map(a => {
+    return {
+      iconName: a.iconName,
+      appNames: a.appNames.replaceAll("\"", "").split(" | "),
+    }
+  }), null, 4)
+
+  fs.writeFileSync("./dist/icon_map.json", iconMapJson, "utf-8");
+
   return { iconMapBashFn };
 }
 


### PR DESCRIPTION
this merge requests extends the build script to also produce an icon map in json format as an alternative to those who are not using lua or shell but other scripting languages for their dotfiles and would like to make use of json as a independent data structure instead