### PR TITLE
Update :music: mapping for chromatix

### DIFF
--- a/mappings/:music:
+++ b/mappings/:music:
@@ -1,1 +1,1 @@
-"Music" | "音乐" | "Musique" | "ミュージック" | "Musik"
+"Music" | "音乐" | "Musique" | "ミュージック" | "Musik" | "Chromatix"


### PR DESCRIPTION
Chromatix is an alternative GUI music client for Plexamp and Jellyfin users. Its icon looks like the default music icon on Mac, so it will work well with the existing icons.