### PR TITLE
More robust legcord mapping

### DIFF
--- a/mappings/:legcord:
+++ b/mappings/:legcord:
@@ -1,1 +1,1 @@
-"legcord"
+"legcord" | "Legcord"


### PR DESCRIPTION
Original mapping had lowercase l but on my machine it uses uppercase.