### PR TITLE
Update fix pnpm-workspace.yaml for package configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+packages:
+  - .
 allowBuilds:
   ttf2woff2: true


### PR DESCRIPTION
I was having some trouble building the project and installing dependencies, which I traced back to the recently added pnpm-workspace.yaml file. This file was missing the required packages field, causing pnpm commands (including pnpm --version when run from the repository root) to fail with "ERROR packages field missing or empty". This PR adds an explicit packages entry while preserving the existing allowBuilds configuration. This fixes the issue on my end.