### PR TITLE
Fix malformed `:tower:` SVG by removing duplicate `clip-rule` attribute

### DIFF
--- a/svgs/:tower:.svg
+++ b/svgs/:tower:.svg
@@ -1,5 +1,4 @@
 <svg viewBox="0 0 24 24" width="24" height="24" xmlns="http://www.w3.org/2000/svg">
   <path fill-rule="nonzero" clip-rule="nonzero"
-    d="M5.7 1H18v1h1.1l-.9 3.8H17v.9h.7V8h.7l.2 1.3h.7l.8 2.4-3 5.2H17V22h-1v.9H8v-1h-.8V17H7l-3-5.2.9-2.4h.5L5.5 8h.8V6.7h.6v-1H5.6L4.6 2h1V1zm3.2 4.8v.9h.6v-1h-.6zm2.6 0v.9h1v-1h-1zm3 0v.9h.5v-1h-.5zm-5.3 11v3.3h.3v-3.2h-.3zm2.3 0v3.3h1.2v-3.2h-1.2zm3.2 0v3.3h.2v-3.2h-.2zm-3.6-2h2l1.1-2.2H10L11 15zm-3.5-2.2L8.8 15H8l-1.3-2.3h1zm8.9 0L15.3 15h.7l1.3-2.3h-.8z"
-    clip-rule="nonzero"></path>
+    d="M5.7 1H18v1h1.1l-.9 3.8H17v.9h.7V8h.7l.2 1.3h.7l.8 2.4-3 5.2H17V22h-1v.9H8v-1h-.8V17H7l-3-5.2.9-2.4h.5L5.5 8h.8V6.7h.6v-1H5.6L4.6 2h1V1zm3.2 4.8v.9h.6v-1h-.6zm2.6 0v.9h1v-1h-1zm3 0v.9h.5v-1h-.5zm-5.3 11v3.3h.3v-3.2h-.3zm2.3 0v3.3h1.2v-3.2h-1.2zm3.2 0v3.3h.2v-3.2h-.2zm-3.6-2h2l1.1-2.2H10L11 15zm-3.5-2.2L8.8 15H8l-1.3-2.3h1zm8.9 0L15.3 15h.7l1.3-2.3h-.8z"></path>
 </svg>


### PR DESCRIPTION
## What does this PR add or change?

`svgs/:tower:.svg` had `clip-rule` declared twice on the same `<path>`, which is invalid XML and can break strict SVG parsers.  
This update makes the icon well-formed by keeping a single `clip-rule="nonzero"` declaration.

- **SVG validity fix**
  - Removed the duplicate `clip-rule` on the `:tower:` path element.
- **Behavior impact**
  - No visual/icon logic change intended; this is a schema/well-formedness correction for parser compatibility.

```xml
<path fill-rule="nonzero" clip-rule="nonzero" d="..."></path>
```

## Checklist

- [x] SVG file(s) placed in `svgs/` with `:snake_case_name:.svg` filename format
- [x] Each SVG uses a `24x24` viewBox
- [x] SVG(s) optimised with [SVGOMG](https://jakearchibald.github.io/svgomg/) (or equivalent)
- [x] Mapping file(s) added to `mappings/` with matching name (no `.svg` extension)
- [x] Mapping file lists all relevant app name variants in `"App Name 1" | "App Name 2"` format
- [x] Tested locally with `pnpm run build:dev` — no errors and glyphs look correct in the browser preview

## Preview

<!-- Optional: attach a screenshot of the glyph from the browser preview at http://localhost:3003 -->