### PR TITLE
jellyfin desktop mapping

### DIFF
--- a/mappings/:jellyfin:
+++ b/mappings/:jellyfin:
@@ -1,1 +1,1 @@
-"Jellyfin Media Player"
+"Jellyfin Media Player" | "Jellyfin Desktop"


### PR DESCRIPTION
jellyfin media player got renamed to jellyfin desktop: see https://github.com/jellyfin-archive/jellyfin-desktop-qt/releases/tag/v2.0.0

## What does this PR add or change?

<!-- Brief description: which app(s) / icons are added, or what is fixed -->
add mapping for `Jellyfin Desktop`

## Checklist

- [ ] SVG file(s) placed in `svgs/` with `:snake_case_name:.svg` filename format
- [ ] Each SVG uses a `24x24` viewBox
- [ ] SVG(s) optimised with [SVGOMG](https://jakearchibald.github.io/svgomg/) (or equivalent)
- [ ] Mapping file(s) added to `mappings/` with matching name (no `.svg` extension)
- [ ] Mapping file lists all relevant app name variants in `"App Name 1" | "App Name 2"` format
- [ ] Tested locally with `pnpm run build:dev` — no errors and glyphs look correct in the browser preview
- [ ] Closes any related icon request issue(s) (use `Closes #<issue>` in the description above)

## Preview

<!-- Optional: attach a screenshot of the glyph from the browser preview at http://localhost:3003 -->
