### PR TITLE
Map Dota 2's actual macOS app name

### DIFF
--- a/mappings/:dota2:
+++ b/mappings/:dota2:
@@ -1,1 +1,1 @@
-"Dota2"
+"Dota2" | "Dota 2"

--- a/mappings/:dota2:
+++ b/mappings/:dota2:
@@ -1,1 +1,1 @@
-"Dota2" | "Dota 2"
+"Dota 2"


### PR DESCRIPTION
## What does this PR add or change?

Fixes the `:dota2:` mapping so it matches a running Dota 2 window. No SVG changes — the glyph already exists.

The mapping listed only `"Dota2"`, which nothing reports. The real bundle:

| key | value |
| --- | --- |
| `CFBundleName` / `CFBundleDisplayName` | `Dota 2` |
| `CFBundleExecutable` | `dota2` |

`icon_map` is a case-sensitive bash `case`, so `"Dota2"` matches neither of those. It's replaced rather than kept alongside.

```diff
- "Dota2"
+ "Dota 2"
```

Verified on macOS 26.5.2 against `com.valvesoftware.dota2` — AeroSpace reports the window as `Dota 2`. `node ./validate.js` passes: 576 mappings, 626 SVGs.

## Checklist

- [ ] SVG file(s) placed in `svgs/` with `:snake_case_name:.svg` filename format
- [ ] Each SVG uses a `24x24` viewBox
- [ ] SVG(s) optimised with [SVGOMG](https://jakearchibald.github.io/svgomg/) (or equivalent)
- [x] Mapping file(s) added to `mappings/` with matching name (no `.svg` extension)
- [x] Mapping file lists all relevant app name variants in `"App Name 1" | "App Name 2"` format
- [ ] Tested locally with `pnpm run build:dev` — no errors and glyphs look correct in the browser preview
- [ ] Closes any related icon request issue(s) (use `Closes #<issue>` in the description above)

SVG boxes are unticked because this touches no SVG; I ran `node ./validate.js` instead of `build:dev` since there's no new glyph to preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
