### PR TITLE
test: remove temporary star test icon

### DIFF
--- a/svgs/:star_test:.svg
+++ b/svgs/:star_test:.svg
@@ -1,3 +1,0 @@
-<svg viewBox="0 0 24 24" width="24" height="24" xmlns="http://www.w3.org/2000/svg">
-  <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-</svg>


### PR DESCRIPTION
Removes the :star_test: icon added for the auto-release end-to-end test.