### PR TITLE
Map "cmux NIGHTLY" to :cmux:

### DIFF
--- a/mappings/:cmux:
+++ b/mappings/:cmux:
@@ -1,1 +1,1 @@
-"cmux"
+"cmux" | "cmux NIGHTLY"


### PR DESCRIPTION
## What does this PR add or change?

Adds the cmux nightly channel to the existing `:cmux:` mapping. No new SVG or glyph — this is a mapping-only alias.

cmux ships a separate nightly bundle alongside the stable one:

| Channel | Bundle ID | App name reported to sketchybar |
| --- | --- | --- |
| stable | `com.cmuxterm.app` | `cmux` |
| nightly | `com.cmuxterm.app.nightly` | `cmux NIGHTLY` |

Verified on macOS with `yabai -m query --windows` → `"app":"cmux NIGHTLY"`, and both `CFBundleDisplayName` and `CFBundleName` in the nightly bundle's `Info.plist` are `cmux NIGHTLY` (uppercase).

```diff
-"cmux"
+"cmux" | "cmux NIGHTLY"
```

This follows the established convention for pre-release channels in this repo — aliasing them onto the stable icon rather than adding a separate glyph:

- `:discord:` → `"Discord" | "Discord Canary" | "Discord PTB"`
- `:code:` → `"Code" | "Code - Insiders"`
- `:google_chrome:` → includes `"Google Chrome Canary"`
- `:zen_browser:` → includes `"Twilight"`

## Checklist

- [x] ~~SVG file(s) placed in `svgs/`~~ — N/A, no new SVG (reuses existing `:cmux:`)
- [x] ~~Each SVG uses a `24x24` viewBox~~ — N/A, no new SVG
- [x] ~~SVG(s) optimised with SVGOMG~~ — N/A, no new SVG
- [x] Mapping file already exists in `mappings/:cmux:` with matching name
- [x] Mapping file lists all relevant app name variants in `"App Name 1" | "App Name 2"` format
- [x] Tested locally — `pnpm run validate` passes (591 mappings / 641 SVGs). Since there is no new glyph to inspect visually, I verified by running `pnpm run build` and diffing the generated `dist/icon_map.sh` against the published `v2.0.71` release asset: the only difference is the intended one line.
- [x] No related icon request issue

```diff
291c291
<    "cmux")
---
>    "cmux" | "cmux NIGHTLY")
```

## Preview

No preview attached — no glyph changes, the nightly channel simply resolves to the existing `:cmux:` icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
