### PR TITLE
new zoom name

### DIFF
--- a/mappings/:zoom:
+++ b/mappings/:zoom:
@@ -1,1 +1,1 @@
-"zoom.us"
+"zoom.us" | "Zoom"


### PR DESCRIPTION
as of around version 7.1.5, zoom finally got named "Zoom"

## What does this PR add or change?

adds `"Zoom"` to `:zoom:`

## Checklist

- [ ] SVG file(s) placed in `svgs/` with `:snake_case_name:.svg` filename format
- [ ] Each SVG uses a `24x24` viewBox
- [ ] SVG(s) optimised with [SVGOMG](https://jakearchibald.github.io/svgomg/) (or equivalent)
- [ ] Mapping file(s) added to `mappings/` with matching name (no `.svg` extension)
- [ ] Mapping file lists all relevant app name variants in `"App Name 1" | "App Name 2"` format
- [ ] Tested locally with `pnpm run build:dev` — no errors and glyphs look correct in the browser preview
- [ ] Closes any related icon request issue(s) (use `Closes #<issue>` in the description above)

## Preview

<!-- Optional: attach a screenshot of the glyph from the browser preview at http://localhost:3003 -->
