### PR TITLE
Add Carbon Copy Cloner icon

### DIFF
--- a/mappings/:carbon_copy_cloner:
+++ b/mappings/:carbon_copy_cloner:
@@ -1,0 +1,1 @@
+"Carbon Copy Cloner"

--- a/svgs/:carbon_copy_cloner:.svg
+++ b/svgs/:carbon_copy_cloner:.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M18.16 19.88A10 10 0 1 1 18.16 4.12L16 6.88A6.5 6.5 0 1 0 16 17.12Z"/></svg>


### PR DESCRIPTION
Adds a glyph + mapping for Carbon Copy Cloner (`com.bombich.ccc`).

- `svgs/:carbon_copy_cloner:.svg` — a bold open-ring "C" (the CCC brand mark), 24x24 viewBox, single path
- `mappings/:carbon_copy_cloner:` — "Carbon Copy Cloner"

Checked with `node ./build.js`: validates and builds cleanly (no svgtofont warnings).